### PR TITLE
Create test image for Windows

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -57,7 +57,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir buildRoot
 
-    commandLine 'make', 'clean', 'images'
+    commandLine 'make', 'clean', 'images', 'test-image-hotspot-jtreg-native', 'test-image-jdk-jtreg-native'
 }
 
 task copyImage(type: Copy) {
@@ -67,8 +67,17 @@ task copyImage(type: Copy) {
     into "$buildRoot/build"
 }
 
-task packageJdk(type: Zip) {
+task packageTestImage(type: Zip) {
     dependsOn copyImage
+    archiveName "${project.correttoTestImageArchiveName}.zip"
+    from("${copyImage.destinationDir}/test") {
+        include '**'
+    }
+    into project.correttoTestImageArchiveName
+}
+
+task packageBuildResults(type: Zip) {
+    dependsOn packageTestImage
     archiveName  = "unsigned-jdk-image.zip"
 
     from("${copyImage.destinationDir}/jdk") {
@@ -84,5 +93,5 @@ task packageJdk(type: Zip) {
 }
 
 artifacts {
-    archives packageJdk
+    archives packageBuildResults
 }


### PR DESCRIPTION
### Description
The TestImage is required for jtreg tests and is not currently produced for Windows. It should be build for Windows and uploaded as an artifact of the the build similar to how it is done for GenericLinux builds.



### How has this been tested?
Test Corretto15 Windows build and verify testimage archive `amazon-corretto-testimage-15-15.0.36.0.1.x64.zip`.


### Platform information
    Works on OS: [e.g. Windows only]
    Applies to version [e.g. "15" (see output from "java -version")]


### Additional context
