### PR TITLE
Allow setting verison opt and version date at build time.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,16 @@ allprojects {
                 "--with-vendor-version-string=Corretto-${project.version.full}"
         ]
 
+        def versionOpt = project.findProperty("corretto.versionOpt")
+        if (versionOpt) {
+            correttoCommonFlags += ["--with-version-opt=${versionOpt}"]
+        }
+
+        def versionDate = project.findProperty("corretto.versionDate")
+        if (versionDate) {
+            correttoCommonFlags += ["--with-version-date=${versionDate}"]
+        }
+
         // Valid value: null, release, debug, fastdebug, slowdebug
         def correttoDebugLevel = "release" // Default: release
         switch(project.findProperty("corretto.debug_level")) {


### PR DESCRIPTION
Set the version opt field and the version date at build time. Default behavior remains unchanged.

openjdk version "15.0.1" 2020-11-24
OpenJDK Runtime Environment Corretto-15.0.1.9.1 (build 15.0.1+9-version-opt)
OpenJDK 64-Bit Server VM Corretto-15.0.1.9.1 (build 15.0.1+9-version-opt, mixed mode)
