### PR TITLE
corretto-jdk-29: Set legal directory file permissions

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -162,6 +162,14 @@ task generateJdkDeb(type: Deb) {
 
     from(jdkBinaryDir) {
         into jdkHome
+        exclude 'legal'
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkBinaryDir}/legal") {
+        into "${jdkHome}/legal"
+        fileMode 0444
     }
 
     from("$buildRoot/jinfo") {

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -118,6 +118,14 @@ task generateJdkRpm(type: Rpm) {
 
     from(jdkBinaryDir) {
         into jdkHome
+        exclude 'legal'
+    }
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkBinaryDir}/legal") {
+        into "${jdkHome}/legal"
+        fileMode 0444
     }
 }
 

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -128,12 +128,19 @@ task packageBuildResults(type: Tar) {
         include 'conf/**'
         include 'include/**'
         include 'jmods/**'
-        include 'legal/**'
         include 'lib/**'
         include 'man/man1/**'
         include 'release'
+        into project.correttoJdkArchiveName
     }
-    into project.correttoJdkArchiveName
+
+    // Copy legal directory specifically to set permission correctly.
+    // See https://github.com/corretto/corretto-11/issues/129
+    from("${jdkResultingImage}/legal") {
+        include '**'
+        fileMode 0444
+        into "${project.correttoJdkArchiveName}/legal"
+    }
 }
 
 artifacts {


### PR DESCRIPTION
Legal directory is make from symlinks which don't preserve the file permissions.
Exclude legal from the bulk file copy and add with correct fileMode to ensure
files are not executable or writable.

Port of https://github.com/corretto/corretto-11/pull/131/commits/e16b7a6e70927c17631b97d9d222b2935667e62a

### How has this been tested?
Built locally and checked permissions.