### PR TITLE
Add the link to the "JDK main-line development" repo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,10 @@ Please read these files: "LICENSE", "ADDITIONAL_LICENSE_INFO", "ASSEMBLY_EXCEPTI
 ### Branches
 
 _develop_
-: The default branch. The branch that consumes development and patches to upstream jdk17u. Corretto builds are generated from this branch.
+: The default branch. The branch that consumes development and patches to upstream jdk. Corretto builds are generated from this branch.
 
-_upstream-jdk17_
-: The branch is similar to master at [openjdk/jdk17](https://github.com/openjdk/jdk17). This branch merges into release branches.
-
-_upstream-jdk17u_
-: The branch is similar to master at [openjdk/jdk17u](https://github.com/openjdk/jdk17u). This branch merges into develop.
+_upstream-jdk_
+: The branch is similar to master at [openjdk/jdk](https://github.com/openjdk/jdk). This branch merges into develop.
 
 ### OpenJDK Readme
 ```


### PR DESCRIPTION
The readme text is updated, the link to the mainline JDK repo is added instead of jdk17.
