### PR TITLE
Start the tests for PR and push

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -2,9 +2,11 @@ name: Pre-submit tests
 
 on:
   push:
-    branches-ignore:
-      - master
-      - pr/*
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
This change will limit the amount of testing we run:
  * The tests will be triggered for PR and push to the develop branch 
  * It will not be run automatically if the user will push the change to their own fork/branch.

The main point is to trigger it for PR, other things can be tweaked later.