### PR TITLE
Update for '8275252: Migrate cacerts from JKS to password-less PKCS12'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,7 @@ project(':prebuild') {
                 '-srckeystore', "$rootDir/amazon-cacerts",
                 '-srcstorepass', keystore_password,
                 '-destkeystore', caCerts,
-                '-deststorepass', keystore_password
+                '-deststorepass', ''
     }
 
     task copyCacerts(type: Copy) {


### PR DESCRIPTION
cacerts is now passwordless, updating the build scripts to match new behavior.
