### PR TITLE
Add dependency on log4j-cve-2021-44228-static-mitigation

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -150,6 +150,7 @@ Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: ca-certificates
+Requires: log4j-cve-2021-44228-cve-mitigations
 Requires(post): chkconfig
 Requires(postun): chkconfig
 
@@ -398,5 +399,7 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %changelog
+* Tue Dec 16 2021 Clive Verghese <verghese@amazon.com> 
+- Add requires for log4j CVE-2021-44228 static mitigation
 * Mon Nov 22 2021 Dan Lutker <lutkerd@amazon.com>
 - Setup AL2 package for CorrettoJdk


### PR DESCRIPTION
### Description

Add dependency on `log4j-cve-2021-44228-cve-mitigations` for AL2 packages.


