### PR TITLE
Include debug symbols from lib/server into package

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -128,6 +128,7 @@ task packageDebugSymbols(type: Tar) {
     from(jdkResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
+        include 'lib/server/*.diz'
         into "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}"
     }
 }

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -118,6 +118,7 @@ task packageDebugSymbols(type: Tar) {
     from(jdkResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
+        include 'lib/server/*.diz'
         into project.correttoDebugSymbolsArchiveName
     }
 }

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -158,6 +158,7 @@ task packageDebugSymbols(type: Tar) {
     from("${jdkResultingImage}/${correttoMacDir}") {
         include "Contents/Homebin/bin/*.diz"
         include "Contents/Homebin/lib/*.diz"
+        include "Contents/Homebin/lib/server/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -83,6 +83,7 @@ task packageDebugSymbols(type: Zip) {
     from("${copyImage.destinationDir}/jdk") {
         include 'bin/*.diz'
         include 'lib/*.diz'
+        include 'lib/server/*.diz'
         into project.correttoDebugSymbolsArchiveName
     }
 }


### PR DESCRIPTION
### Description
Debug symbols skipped diz files from lib/server. Include them in the debug symbol package. 

