### PR TITLE
Fix Linux universal RPM metadata version numbers

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -110,11 +110,11 @@ task generateJdkRpm(type: Rpm) {
     preUninstall file("$buildRoot/scripts/preun_javac.sh")
 
     provides(jdkPackageName, "${epoch}:${version}-${release}", EQUAL)
-    provides('java-17-devel', "${epoch}:${version}", EQUAL)
-    provides('java-17-openjdk-devel', "${epoch}:${version}", EQUAL)
-    provides('java-17-openjdk-devel', "${epoch}:${version}-${release}", EQUAL)
-    provides('java-sdk-17', "${epoch}:${version}", EQUAL)
-    provides('java-sdk-17-openjdk ', "${epoch}:${version}-${release}", EQUAL)
+    provides("java-${project.version.major}-devel", "${epoch}:${version}", EQUAL)
+    provides("java-${project.version.major}-openjdk-devel", "${epoch}:${version}", EQUAL)
+    provides("java-${project.version.major}-openjdk-devel", "${epoch}:${version}-${release}", EQUAL)
+    provides("java-sdk-${project.version.major}", "${epoch}:${version}", EQUAL)
+    provides("java-sdk-${project.version.major}-openjdk", "${epoch}:${version}-${release}", EQUAL)
 
     from(jdkBinaryDir) {
         into jdkHome


### PR DESCRIPTION
Use the project major-version for the RPM provides
metadata. We're already on major version 19, and it
will keep changing.

Before:

(after building with `./gradlew :installers:linux:universal:rpm:build`)

```
rpm -qp --queryformat '[%{PROVIDENAME}\n]' installers/linux/universal/rpm/corretto-build/distributions/java-19-amazon-corretto-devel-19.0.0.5-1.x86_64.rpm
java-19-amazon-corretto-devel
java-17-devel
java-17-openjdk-devel
java-sdk-17
java-sdk-17-openjdk
```

After:

```
rpm -qp --queryformat '[%{PROVIDENAME}\n]' installers/linux/universal/rpm/corretto-build/distributions/java-19-amazon-corretto-devel-19.0.0.5-1.x86_64.rpm
java-19-amazon-corretto-devel
java-19-devel
java-19-openjdk-devel
java-sdk-19
java-sdk-19-openjdk
```

There was also a trailing space in the final entry, which I can only
assume was a mistake, so I've removed it.
