### PR TITLE
Update .deb build 'provides' to include version 18

### DIFF
--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -145,7 +145,9 @@ task generateJdkDeb(type: Deb) {
     provides('java7-jdk')
     provides('java8-jdk')
     provides('java11-sdk')
-    provides('java17-sdk')
+    17.upto(project.version.major.toInteger()) {
+      provides("java${it}-sdk")
+    }
     // TODO: Move this to the jre when splitting the fat deb
     provides('java-runtime')
     provides('java5-runtime')
@@ -153,7 +155,9 @@ task generateJdkDeb(type: Deb) {
     provides('java7-runtime')
     provides('java8-runtime')
     provides('java11-runtime')
-    provides('java17-runtime')
+    17.upto(project.version.major.toInteger()) {
+      provides("java${it}-runtime")
+    }    
     // TODO: Move this to the headless jre when splitting the fat deb
     provides('java-runtime-headless')
     provides('java5-runtime-headless')
@@ -161,7 +165,9 @@ task generateJdkDeb(type: Deb) {
     provides('java7-runtime-headless')
     provides('java8-runtime-headless')
     provides('java11-runtime-headless')
-    provides('java17-runtime-headless')
+    17.upto(project.version.major.toInteger()) {
+      provides("java${it}-runtime-headless")
+    }
 
     from(jdkBinaryDir) {
         into jdkHome


### PR DESCRIPTION
I don't know exactly what practical effect this has for consumers, but it's a while out of date. Adding at least 18.

Confirmed that this updates the `.deb` as expected, after `./gradlew :installers:linux:universal:deb:build`.

After:
```
ar vx java-19-amazon-corretto-jdk_19.0.0.5-1_amd64.deb
tar -xzf control.tar.gz
grep Provides control
Provides: java-compiler, java-sdk, java5-sdk, java6-sdk, java7-sdk, java7-jdk, java8-jdk, java11-sdk, java17-sdk, java18-sdk, java-runtime, java5-runtime, java6-runtime, java7-runtime, java8-runtime, java11-runtime, java17-runtime, java18-runtime, java-runtime-headless, java5-runtime-headless, java6-runtime-headless, java7-runtime-headless, java8-runtime-headless, java11-runtime-headless, java17-runtime-headless, java18-runtime-headless
```
