### PR TITLE
Add hostArchitectures to macos pkg files so Rosetta is not required on m1

### DIFF
--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -48,7 +48,7 @@ task inflatePkgTemplate {
         copy {
             from('templates/CorrettoPkg.pkgproj.template') {
                 rename { file -> file.replace('.template', '') }
-                filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ["full": project.version["full"], "major": project.version["major"], "arch": correttoArch])
+                filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ["full": project.version["full"], "major": project.version["major"], "arch": correttoArch, "macos-arch": (correttoArch == "aarch64" ? "arm64" : "x86_64")])
             }
             into buildRoot
         }

--- a/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
+++ b/installers/mac/pkg/templates/CorrettoPkg.pkgproj.template
@@ -379,6 +379,13 @@
     </dict>
     <key>PROJECT_SETTINGS</key>
     <dict>
+      <key>ADVANCED_OPTIONS</key>
+      <dict>
+        <key>installer-script.options:hostArchitectures</key>
+        <array>
+          <string>@macos-arch@</string>
+        </array>
+      </dict>
       <key>BUILD_FORMAT</key>
       <integer>0</integer>
       <key>BUILD_PATH</key>


### PR DESCRIPTION
This is a forward port of [this](https://github.com/corretto/corretto-17/commit/b542e194e7f8984fe5000b8ff2385e446baa1729)  fix to the corretto-jdk, later it will be ported to the corretto-18.