### PR TITLE
Fix path typo in packaging Mac debug symbols.

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -156,9 +156,9 @@ task packageDebugSymbols(type: Tar) {
     archiveName "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
     from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Homebin/bin/*.diz"
-        include "Contents/Homebin/lib/*.diz"
-        include "Contents/Homebin/lib/server/*.diz"
+        include "Contents/Home/bin/*.diz"
+        include "Contents/Home/lib/*.diz"
+        include "Contents/Home/lib/server/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName


### PR DESCRIPTION
This is a forward port [this](https://github.com/corretto/corretto-17/pull/22/files) fix from corretto-17. The difference in corretto-jdk is that we have one more typo. This fix will be backported to the corretto-18.