### PR TITLE
Ignore whole-file checksum in VerifyCACerts

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -289,12 +289,16 @@ public class VerifyCACerts {
         md = MessageDigest.getInstance("SHA-256");
 
         byte[] data = Files.readAllBytes(Path.of(CACERTS));
+        /* Ignore whole-file checksum as the checksum of the cacerts 
+         * file changes with each build, due to the way we merge upstream 
+         * OpenJDK certs and Amazon Linux certs at build time.
         String checksum = HEX.formatHex(md.digest(data));
         if (!checksum.equals(CHECKSUM)) {
             atLeastOneFailed = true;
             System.err.println("ERROR: wrong checksum\n" + checksum);
             System.err.println("Expected checksum\n" + CHECKSUM);
         }
+        */
 
         KeyStore ks = KeyStore.getInstance("JKS");
         ks.load(new ByteArrayInputStream(data), "changeit".toCharArray());


### PR DESCRIPTION
Similar to
https://github.com/corretto/corretto-11/commit/d9720b825223b08b38870063cc7902718658d7fb,
this check doesn't make any sense because the file is re-created on
every build and contains dynamic components so it the checksum is
different each time, causing failures in this test (which is not run
in our GitHub checks because it's tier2, so it's easy to miss).

An alternative would be to pre-generate the merged certs and commit
that, but just following what was done in Corretto 11 instead.