### PR TITLE
Relax VerifyCACerts expiry condition

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -343,27 +343,26 @@ public class VerifyCACerts {
                         + e.getMessage());
             }
 
-            // Make sure cert is not expired or not yet valid
             try {
                 cert.checkValidity();
             } catch (CertificateExpiredException cee) {
-                if (!EXPIRY_EXC_ENTRIES.contains(alias)) {
-                    atLeastOneFailed = true;
-                    System.err.println("ERROR: cert is expired");
-                }
+                // Ignore - we have an 'is very expired' check later
             } catch (CertificateNotYetValidException cne) {
                 atLeastOneFailed = true;
                 System.err.println("ERROR: cert is not yet valid");
             }
 
-            // If cert is within 90 days of expiring, mark as failure so
-            // that cert can be scheduled to be removed/renewed.
+            // If cert is more than 90 days *past* expiry, mark as failure so
+            // we can alert either OpenJDK upstream or Amazon Linux.
+            // This is different to the upstream failure condition, which fails
+            // 90 days *before* expiry. Our condition is more relaxed because we
+            // rely on OpenJDK/Amazon Linux to manage the certs.
             Date notAfter = cert.getNotAfter();
-            if (notAfter.getTime() - System.currentTimeMillis() < NINETY_DAYS) {
+            if (System.currentTimeMillis() - notAfter.getTime() > NINETY_DAYS) {
                 if (!EXPIRY_EXC_ENTRIES.contains(alias)) {
                     atLeastOneFailed = true;
                     System.err.println("ERROR: cert \"" + alias + "\" expiry \""
-                            + notAfter.toString() + "\" will expire within 90 days");
+                            + notAfter.toString() + "\" has been expired for >90 days.");
                 }
             }
         }


### PR DESCRIPTION
Basically, avoid noise from this test failing a lot, without any
action required to resolve it on our end.

As described in the comment, the current condition (at least 90 days
before expiry, otherwise fail), is unhelpfully strict. It makes sense
for upstream OpenJDK, since they use this as an early warning to take
an action, but we rely on OpenJDK and Amazon Linux to manage the
certificates for us so we do not take action when this condition fails,
at the moment.

So, relax the condition a little to wait for the cert to be 90 days
*past* expiry before failing, at which point something has definitely
gone wrong and we want to investigate.