### PR TITLE
Fix cacerts count

### DIFF
--- a/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
+++ b/test/jdk/sun/security/lib/cacerts/VerifyCACerts.java
@@ -54,7 +54,7 @@ public class VerifyCACerts {
             + File.separator + "security" + File.separator + "cacerts";
 
     // The numbers of certs now.
-    private static final int COUNT = 221;
+    private static final int COUNT = 214;
 
     // SHA-256 of cacerts, can be generated with
     // shasum -a 256 cacerts | sed -e 's/../&:/g' | tr '[:lower:]' '[:upper:]' | cut -c1-95


### PR DESCRIPTION
VerifyCACerts.java is currently failing with:
```
ERROR: 214 entries, should be 221
```

When I updated the count in https://github.com/corretto/corretto-18/commit/f05a9fc051983424667c22239c15198ac0eac654
I was mistakenly checking the count against the certs from the
previous build, so the count is wrong.

JDK certs: 89 (as specified in the test before my update to 221).
Amazon Linux certs before I recently updated them: 132 (+89=221).
Amazon Linux certs after I recently updated them: 125 (+89=214).

89 was always wrong since we add our own certs, 221 would have been
   correct if I hadn't also updated the certs at the same time,
removing 7 AL certs to bring the current correct count to 214.