### PR TITLE
Update src.rpm name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ project(':prebuild') {
 
     task generateJdkCacerts(type: JavaExec) {
         dependsOn buildTool
-        def jdkCaDir = "$rootDir/make/data/cacerts"
+        def jdkCaDir = "$rootDir/src/java.base/share/data/cacerts"
 
         description = 'Generate Cacerts from JDK source'
         classpath = files(classPath)

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -103,6 +103,9 @@ task generateJdkRpm(type: Rpm) {
     packageDescription packageInfo.description
     summary "Amazon Corretto ${project.version.major} development environment"
     packageGroup 'Development/Tools'
+    // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
+    sourcePackage "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+
     prefix(jdkHome)
     postInstall file("$buildRoot/scripts/postin_java.sh")
     postInstall file("$buildRoot/scripts/postin_javac.sh")


### PR DESCRIPTION
Built locally and checked src.rpm name.

$ rpm -qp java-19-amazon-corretto-devel-19.0.0.21-1.x86_64.rpm  --info
Name        : java-19-amazon-corretto-devel
Epoch       : 1
Version     : 19.0.0.21
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Development/Tools
Size        : 348648312
License     : ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
Signature   : (none)
Source RPM  : java-19-amazon-corretto-devel-19.0.0.21-1.src.rpm
Build Date  : Wed 11 May 2022 06:14:48 PM UTC
Build Host  : build.amazon.com
Relocations : /usr/lib/jvm/java-19-amazon-corretto 
Packager    : Amazon
Vendor      : Amazon
URL         : https://github.com/corretto/corretto-jdk
Summary     : Amazon Corretto 19 development environment
Description :
Amazon Corretto's packaging of the runtime core elements of the OpenJDK code.