### PR TITLE
Only require log4j-cve-mitigations on AL2

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -150,7 +150,9 @@ Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: ca-certificates
+%if "%{dist}" == ".amzn2"
 Requires: log4j-cve-2021-44228-cve-mitigations
+%endif
 Requires(post): chkconfig
 Requires(postun): chkconfig
 


### PR DESCRIPTION
Don't require the log4j mitigation on AL2022+
