### PR TITLE
Enable bundled zlib library via Gradle

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -69,6 +69,9 @@ task configureBuild(type: Exec) {
     def command = ['bash', 'configure',
             "--with-cacerts-file=${depsMap[caCerts]}"
     ]
+    if (project.correttoArch == "aarch64") {
+        command += "--with-zlib=bundled"
+    }
     // Common flags
     command += project.correttoCommonFlags
     commandLine command.flatten()


### PR DESCRIPTION
This change will set the bundled version of the zlib library on macOS aarch64 in the gradle script. Note that this is a noop change on corretto-jdk since this is the default option in the make file, but this fix will affect the old versions when I backport it.

See https://bugs.openjdk.org/browse/JDK-8286623 for additional details.