### PR TITLE
Add cleanup to macos installer scripts

### DIFF
--- a/installers/mac/pkg/build.gradle
+++ b/installers/mac/pkg/build.gradle
@@ -60,6 +60,14 @@ task inflatePkgTemplate {
             }
             into "${buildRoot}/resources"
         }
+
+        copy {
+            from('templates/preinstall.template') {
+                rename { file -> file.replace('.template', '') }
+                filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: project.version)
+            }
+            into "${buildRoot}/resources"
+        }
     }
 }
 

--- a/installers/mac/pkg/resources/preinstall
+++ b/installers/mac/pkg/resources/preinstall
@@ -1,9 +1,0 @@
-#!/bin/bash
-JDK_INSTALL_PATH="/Library/Java/JavaVirtualMachines"
-MKDIR=`which mkdir`
-
-if [[ ! -d ${JDK_INSTALL_PATH} ]]; then
-	${MKDIR} -p ${JDK_INSTALL_PATH}
-fi
-
-exit 0

--- a/installers/mac/pkg/templates/preinstall.template
+++ b/installers/mac/pkg/templates/preinstall.template
@@ -1,0 +1,15 @@
+#!/bin/bash
+JDK_INSTALL_PATH="/Library/Java/JavaVirtualMachines"
+CORRETTO_BUNDLE="amazon-corretto-@major@.jdk"
+MKDIR="$(which mkdir)"
+RM="$(which rm)"
+
+if [[ ! -d "${JDK_INSTALL_PATH}" ]]; then
+    ${MKDIR} -p "${JDK_INSTALL_PATH}"
+fi
+
+if [[ -d "${JDK_INSTALL_PATH}/${CORRETTO_BUNDLE}" ]]; then
+    ${RM} -r "${JDK_INSTALL_PATH}/${CORRETTO_BUNDLE}"
+fi
+
+exit 0


### PR DESCRIPTION
This prevents the installer from leaving old files on disk when installing an updated version