### PR TITLE
AL: add jpeg, alsa and fonts as headless dependencies.

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -123,13 +123,8 @@ Requires: libXt
 Requires: libXrender
 Requires: libXrandr
 Requires: libXtst
-Requires: alsa-lib
-#Requires: giflib
-Requires: libjpeg
+Requires: giflib
 Requires: libpng
-Requires: dejavu-sans-fonts
-Requires: dejavu-serif-fonts
-Requires: dejavu-sans-mono-fonts
 # Require headless package.
 Requires: %{name}-headless%{?_isa} = %{epoch}:%{version}-%{release}
 
@@ -157,6 +152,11 @@ Requires: javapackages-filesystem
 Requires: zlib
 Requires: fontconfig
 Requires: freetype
+Requires: dejavu-sans-fonts
+Requires: dejavu-serif-fonts
+Requires: dejavu-sans-mono-fonts
+Requires: alsa-lib
+Requires: libjpeg
 Requires: ca-certificates
 %if "%{dist}" == ".amzn2"
 Requires: log4j-cve-2021-44228-cve-mitigations
@@ -446,6 +446,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %changelog
+* Mon Aug 29 2022 Dan Lutker <lutkerd@amazon.com>
+- Move requires for jpeg, alsa and fonts to headless package
+
 * Thu Aug 18 2022 Dan Lutker <lutkerd@amazon.com>
 - Add ability to set debug_level
 


### PR DESCRIPTION
Fix for https://github.com/amazonlinux/amazon-linux-2022/issues/171

### How has this been tested?
Tested on Corretto17 on AL2 and AL2022. Builds fine and installs the correct dependencies for headless and headful packages.