### PR TITLE
Windows: remove --with-ucrt-dll-dir --with-msvcr-dll from gradle build

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -43,9 +43,7 @@ task configureBuild(type: Exec) {
     def command = ['bash', 'configure',
            "--with-cacerts-file=${depsMap[caCerts]}",
            "--with-boot-jdk=${project.getProperty('bootjdk_dir')}",
-           "--with-ucrt-dll-dir=${project.getProperty('ucrt_dll_dir')}",
            "--with-jtreg=${project.getProperty('jtreg_dir')}",
-           "--with-msvcr-dll=${project.getProperty('vcruntime_dir')}/vcruntime140.dll",
            "--with-zlib=bundled"
     ]
     // Common flags


### PR DESCRIPTION
Configure is able to get dll's needed automatically from VS.
There is still option to specify these via [corretto.extra_config](https://github.com/corretto/corretto-jdk/blob/develop/build.gradle#L136C52-L136C73) in case customization is needed.

