### PR TITLE
Disable build-ids in AL RPMs

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -31,6 +31,9 @@
 %global zlib_option $zlib_option
 %global use_gcc_ver $use_gcc_ver
 
+# Disable build_id links as they can collide between versions of Corretto
+%global _build_id_links none
+
 # The experimental_feature macro gets set to %nil by the template, but that is still defined and
 # the spec doesn't have a quick is not nil check, just define/not defined, this makes it easier to
 # work with


### PR DESCRIPTION
Porting https://github.com/corretto/corretto-21/commit/b6252c49bad35a2ca33106f25cabf5e308e5a331 to tip before backporting to other versions.