### PR TITLE
Package debug symbols for AL builds

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -245,6 +245,13 @@ Requires: %{name}-devel%{?1}%{?_isa} = %{epoch}:%{version}-%{release}
 %description jmods
 Amazon Corretto's packaging of the OpenJDK ${java_spec_version} jmods.
 
+%package debugsymbols
+Summary: Amazon Corretto ${java_spec_version} zipped debug symbols
+Group: Development
+
+%description debugsymbols
+Amazon Corretto's packaging of the OpenJDK ${java_spec_version} debug symbols.
+
 %prep
 %setup -q -n src -c
 
@@ -284,7 +291,7 @@ bash ./configure \\
         --with-vendor-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-vendor-vm-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-debug-level=$debug_level \\
-        --with-native-debug-symbols=none
+        --with-native-debug-symbols=zipped
 
 make images
 make LOG=debug docs
@@ -496,7 +503,18 @@ fi
 %doc %{java_imgdir}/docs/specs
 %license %{java_imgdir}/docs/legal
 
+%files debugsymbols
+%dir %{java_home}/bin
+%dir %{java_home}/lib
+%dir %{java_home}/lib/server
+%{java_home}/bin/*.diz
+%{java_home}/lib/*.diz
+%{java_home}/lib/server/*.diz
+
 %changelog
+* Mon Aug 5 2024 Daniel Hu <costmuch@amazon.com>
+- Add package debug symbols
+
 * Mon Oct 10 2022 Dan Lutker <lutkerd@amazon.com>
 - Fix provides to include public shared libs
 

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -507,6 +507,12 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %files debugsymbols
+<<<<<<< HEAD
+=======
+%dir %{java_home}/bin
+%dir %{java_home}/lib
+%dir %{java_home}/lib/server
+>>>>>>> 85e1c0de3a7 (Package debug symbols for AL builds)
 %{java_home}/bin/*.diz
 %{java_home}/lib/*.diz
 %{java_home}/lib/server/*.diz

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -438,6 +438,9 @@ fi
 %exclude %{java_lib}/libawt_xawt.so
 %exclude %{java_lib}/libjawt.so
 %exclude %{java_lib}/libsplashscreen.so
+# Exclude debug symbol files
+%exclude %{java_home}/lib/*.diz
+%exclude %{java_home}/lib/server/*.diz
 
 %files devel
 %{java_home}/bin/jar
@@ -504,9 +507,6 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %files debugsymbols
-%dir %{java_home}/bin
-%dir %{java_home}/lib
-%dir %{java_home}/lib/server
 %{java_home}/bin/*.diz
 %{java_home}/lib/*.diz
 %{java_home}/lib/server/*.diz


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Adds rpm file package containing debug symbols for AL builds.

### Related issues


### Motivation and context
Debug symbols currently aren't generated for AL builds.

### How has this been tested?
Through internal Jenkins pipeline for AL2 build JDK 17

### Platform information
    Works on OS: AL2, AL2023
    Applies to version 17.0.12.7.1 -> 24.0.0.9.1


### Additional context
