### PR TITLE
Fix incorrect bootjdk version for AL builds

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -52,6 +52,7 @@ task inflateRpmSpec {
                     version_opt         : versionOpt,
                     debug_level         : correttoDebugLevel,
                     boot_jdk_major_version : version.major.toInteger() - 1,
+                    boot_jdk_major_v_backup : version.major.toInteger() - 2,
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
                     additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}",
                     zlib_option: project.findProperty("corretto.zlib_option") ?: "system",

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -53,6 +53,7 @@
 # %global release_ext  1
 
 %global boot_jdk_major_version    $boot_jdk_major_version
+%global boot_jdk_major_v_backup    $boot_jdk_major_v_backup
 
 %global java_home %{_jvmdir}/%{name}.%{_arch}
 %global java_lib  %{java_home}/lib
@@ -146,7 +147,7 @@ BuildRequires: pkgconfig
 BuildRequires: xorg-x11-proto-devel
 
 %if %{with bootjdk}
-BuildRequires: java-${boot_jdk_major_version}-devel
+BuildRequires: (java-${boot_jdk_major_version}-devel or java-${boot_jdk_major_v_backup}-devel)
 %endif
 
 Requires: libX11


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Added a backup boot version and uses `or` conditional dependency

### Related issues


### Motivation and context
AL builds fail due to incorrect bootjdk version

### How has this been tested?
Internal pipelines show that now AL2023 builds pass the bootjdk dependency step

### Platform information
    Works on OS: AL2023
    Applies to version 24.0.0.9.1


### Additional context
