### PR TITLE
Update macos installer to refer to renamed JDK-Info.plist.template

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -112,7 +112,7 @@ task prepareArtifacts {
         plistTokens["VENDOR"] = "Amazon.com Inc."
 
         copy {
-            from("${rootDir}/make/data/bundle/JDK-Info.plist") {
+            from("${rootDir}/make/data/bundle/JDK-Info.plist.template") {
                 rename { file -> 'Info.plist' }
                 filter(org.apache.tools.ant.filters.ReplaceTokens, beginToken: "@@", endToken: "@@", tokens: plistTokens)
             }


### PR DESCRIPTION
### Description
cherry-pick of 2bfeb5ed4c1d8aec448b59d64a8f76c9687ba56f

### Related issues
https://github.com/corretto/corretto-23/pull/2

### Motivation and context


### How has this been tested?
GH sanity test

### Platform information
    Works on OS: macos



### Additional context
