### PR TITLE
Add debug level into alpine build

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -39,9 +39,8 @@ ext {
 		throw new GradleException("${arch} is not suported")
     }
 }
-
-def jdkResultingImage = "$buildRoot/build/linux-${arch}-server-release/images/jdk"
-def testResultingImage = "$buildRoot/build/linux-${arch}-server-release/images/test"
+def jdkResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/jdk"
+def testResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/test"
 
 // deps
 def depsMap = [:]


### PR DESCRIPTION
### Description

Currently the alpine image name does not contain debug level. It does not match debug build folder name format and leads to incomplete JDK in debug builds (JDK does not have any content except for first level files such as README, LICENSE etc). This change fixes the issue.


### Related issues

This is a part of fix for https://github.com/corretto/corretto-22/issues/9. In addition to this fix, we have to fix internal build scripts as well.

Need to backport this change to other versions.

### How has this been tested?

Tested with internal build pipeline and can see right binaries being generated now:

```
/tmp/alpine/fix/amazon-corretto-24.0.0.10.1-alpine-linux-x64 # ./bin/java -version
openjdk version "24" 2025-03-18
OpenJDK Runtime Environment Corretto-24.0.0.10.1 (fastdebug build 24+10-FR)
OpenJDK 64-Bit Server VM Corretto-24.0.0.10.1 (fastdebug build 24+10-FR, mixed mode, sharing)
```

### Platform information

```
/tmp/alpine/fix/amazon-corretto-24.0.0.10.1-alpine-linux-x64 # cat /etc/os-release 
NAME="Alpine Linux"
ID=alpine
VERSION_ID=3.16.9
PRETTY_NAME="Alpine Linux v3.16"
HOME_URL="https://alpinelinux.org/"
BUG_REPORT_URL="https://gitlab.alpinelinux.org/alpine/aports/-/issues"
```
