### PR TITLE
Add corretto.jmh to build microbenchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,12 @@ allprojects {
             correttoCommonFlags += ["--with-gtest=${gtest}"]
         }
 
+        // This should be public so we can know if we should build the micro-benchmarks
+        jmh = project.findProperty("corretto.jmh")
+        if (jmh) {
+            correttoCommonFlags += ["--with-jmh=${jmh}"]
+        }
+
         // Valid value: null, release, debug, fastdebug, slowdebug
         correttoDebugLevel = "release" // Default: release
         switch(project.findProperty("corretto.debug_level")) {


### PR DESCRIPTION
Tested locally with and without the new option and the benchmarks are built correctly as part of the test image.