### PR TITLE
Add ignore_urls flag to AL build

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -56,7 +56,8 @@ task inflateRpmSpec {
                     experimental_feature: project.findProperty("corretto.experimental_feature") ?: "%{nil}",
                     additional_configure_options: project.findProperty("corretto.additional_configure_options") ?: "%{nil}",
                     zlib_option: project.findProperty("corretto.zlib_option") ?: "system",
-                    use_gcc_ver: project.findProperty("corretto.use_gcc_ver") ?: "%{nil}"
+                    use_gcc_ver: project.findProperty("corretto.use_gcc_ver") ?: "%{nil}",
+                    ignore_urls: project.hasProperty("corretto.ignore_urls") ? 1 : 0,
                 ])
         outputs.files.singleFile.text = renderedTemplate
     }

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -30,6 +30,7 @@
 %global additional_configure_options     $additional_configure_options
 %global zlib_option $zlib_option
 %global use_gcc_ver $use_gcc_ver
+%global ignore_urls $ignore_urls
 
 # Disable build_id links as they can collide between versions of Corretto
 %global _build_id_links none
@@ -288,9 +289,11 @@ bash ./configure \\
         --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{build_id}.%{release_id}" \\
         --with-version-pre= \\
         --with-vendor-name="Amazon.com Inc." \\
+%if 0%{?ignore_urls} != 1
         --with-vendor-url="https://aws.amazon.com/corretto/" \\
         --with-vendor-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-vendor-vm-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
+%endif
         --with-debug-level=$debug_level \\
         --with-native-debug-symbols=zipped
 


### PR DESCRIPTION
### Description
This adds a flag to ignore the vendor url configuration arguments when building for AL. When unset, the build script should remain unchanged to the prior logic. When set, the build script will not include url arguments when building AL.

### Related issues
n/a

### Motivation and context
Internal corretto builds might require different vendor url strings to be set, so there should be the option to not include vendor url strings

### How has this been tested?
On internal infrastructure

### Platform information
    Works on OS: AL
    Applies to version: this will be backported to at least jdk11 (unsure if jdk8 needs this change).


### Additional context
n/a
