### PR TITLE
Allow overridable configure arguments for AL build

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -273,9 +273,6 @@ bash ./configure \\
         --with-extra-cflags="%{GIFLIB_DEFINE}" \\
 %endif
 %endif
-%if 0%{?additional_configure_options:1}
-        %{additional_configure_options} \\
-%endif
         --with-jvm-features="zgc shenandoahgc" \\
         --with-version-feature="${java_spec_version}" \\
         --with-freetype=system \\
@@ -292,7 +289,11 @@ bash ./configure \\
         --with-vendor-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-vendor-vm-bug-url="https://github.com/corretto/corretto-${java_spec_version}/issues/" \\
         --with-debug-level=$debug_level \\
-        --with-native-debug-symbols=zipped
+        --with-native-debug-symbols=zipped \\
+%if 0%{?additional_configure_options:1}
+        %{additional_configure_options} \\
+%endif
+# EOL
 
 make images
 make LOG=debug docs


### PR DESCRIPTION
### Description
Alternative solution to #125. When `bash configure` gets duplicated arguments, it uses the last given argument. To take advantage of this, the `additional_configure_options` is moved last so that any passed configure arguments through gradle can override any prior static configure arguments for AL builds

### Related issues
This also solves this issue #125 

### Motivation and context
To allow a way to dynamically set vendor url config args for AL builds

### How has this been tested?
Through internal infrastructure

### Platform information
    Works on OS: AL
    Applies to version: intended to be backported to 11


### Additional context
n/a