### PR TITLE
Fix Windows build.gradle issue with 'clean' not working.

### DIFF
--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -54,7 +54,7 @@ task executeBuild(type: Exec) {
     dependsOn configureBuild
     workingDir buildRoot
 
-    commandLine 'make', 'clean', 'images', 'test-image'
+    commandLine 'make', 'images', 'test-image'
 }
 
 task copyImage(type: Copy) {


### PR DESCRIPTION
Target is now 'make images test-image'.

Tested on Windows with VS2019

`make clean images test-image` fails.
`make images test-image` succeeds building.


