### PR TITLE
Remove policy files as part of JEP 486

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,12 +77,10 @@ allprojects {
             'conf/security/policy/limited/default_US_export.policy',
             'conf/security/policy/unlimited/default_local.policy',
             'conf/security/policy/unlimited/default_US_export.policy',
-            'conf/security/java.policy',
             'conf/security/java.security',
             'conf/management/jmxremote.access',
             'conf/management/management.properties',
             'lib/security/blocked.certs',
-            'lib/security/default.policy',
             'lib/security/public_suffix_list.dat'
             ];
 

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -410,7 +410,6 @@ fi
 %config(noreplace) %{java_home}/conf/sound.properties
 %config(noreplace) %{java_home}/conf/management/jmxremote.access
 %config(noreplace) %{java_home}/conf/management/management.properties
-%config(noreplace) %{java_home}/conf/security/java.policy
 %config(noreplace) %{java_home}/conf/security/java.security
 %config(noreplace) %{java_home}/conf/security/policy/limited/exempt_local.policy
 %config(noreplace) %{java_home}/conf/security/policy/limited/default_local.policy
@@ -418,7 +417,6 @@ fi
 %config(noreplace) %{java_home}/conf/security/policy/unlimited/default_local.policy
 %config(noreplace) %{java_home}/conf/security/policy/unlimited/default_US_export.policy
 %config(noreplace) %{java_home}/lib/security/blocked.certs
-%config(noreplace) %{java_home}/lib/security/default.policy
 %config(noreplace) %{java_home}/lib/security/public_suffix_list.dat
 %dir %{java_home}
 %dir %{java_home}/bin


### PR DESCRIPTION
Builds are looking for .policy files that were removed as part of JEP 486. Remove these from java-amazon-corretto.spec.template and build.gradle per https://github.com/corretto/corretto-24/commit/d9621fc8f3498e98a3c1a05dc140edff5a04f571 and https://github.com/corretto/corretto-24/commit/df3a0023954094ec6943f9ce214e12a32d3d8a90