### PR TITLE
Using project.version.major instead of version.major

### DIFF
--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -74,7 +74,7 @@ task copySourceTar(type: Tar) {
         into '/'
     }
     // Include the man pages tarball if it exists
-    from(file("${buildDir}/distributions/jdk${version.major}-manpages.tar.gz")) {
+    from(file("${buildDir}/distributions/jdk${project.version.major}-manpages.tar.gz")) {
         into '/'
     }
 }


### PR DESCRIPTION
Noticed build was failing for alpine and centos with the below message. Things succeed with the included change.

```
Build file '/home/jenkins/node/workspace/CorrettoJdk/generic_linux/x64/build/CorrettoJdkSrc/installers/linux/al2/spec/build.gradle' line: 77

* What went wrong:
A problem occurred evaluating project ':installers:linux:al2:spec'.
> No such property: major for class: java.lang.String
...
```