### PR TITLE
Fix update-version.sh to work for initial and update releases

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -7,7 +7,11 @@ UPSTREAM_REMOTE=$1
 # Load the current OpenJDK version
 source make/conf/version-numbers.conf
 
-BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}+ | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
+if [[ "${DEFAULT_VERSION_UPDATE}" == "0" ]]; then
+    BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}+ | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
+else
+    BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE} | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
+fi
 
 # Load the current Corretto version
 CURRENT_VERSION=$(cat version.txt)


### PR DESCRIPTION
Tested on Corretto-jdk and Corretto-25 and its working correctly. Will backport to 25 after merge.