### PR TITLE
Enable version.txt automerge from develop for leyden

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -44,3 +44,11 @@ jobs:
                 git fetch $UPSTREAM_LEYDEN premain || exit 1
                 git merge -m "Merging openjdk/leyden:premain to corretto-jdk:leyden" FETCH_HEAD
                 git push origin $LOCAL_LEYDEN
+
+            - name: "Update leyden version.txt from develop"
+              shell: bash
+              run: |
+                git checkout $LOCAL_LEYDEN
+                git restore --source origin/$LOCAL_BRANCH --staged --worktree -- version.txt
+                git commit -m "Automerged version.txt from $LOCAL_BRANCH to $LOCAL_LEYDEN" || true
+                git push origin $LOCAL_LEYDEN


### PR DESCRIPTION
The [version.txt file in leyden](https://github.com/corretto/corretto-jdk/blob/leyden/version.txt) branch has not been updated since Feburary, causing tests to fail. This was initially enabled alongside automatic merges from develop shortly after leyden branch was set up, but it [was disabled](https://github.com/corretto/corretto-jdk/commit/8e17aebd60e32781d5359a608e27ba6864baaed5) after it caused too many merge failures. This commit re-enables the version.txt sync from develop, not the full merges.

Tested by running the commands on personal fork. https://github.com/midver/corretto-jdk/tree/leyden