### PR TITLE
Add additional build targets option for Mac

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,8 @@ allprojects {
         asyncProfilerBinariesPath = project.findProperty("asyncProfilerBinariesPath") ?: ""
         asyncProfilerLegal = "${rootDir}/installers/legal/async-profiler.md"
 
+        additionalMakeTargets = (project.findProperty('corretto.additional_make_targets') ?: "").tokenize(',')
+
         // Valid value: null, release, debug, fastdebug, slowdebug
         correttoDebugLevel = "release" // Default: release
         switch(project.findProperty("corretto.debug_level")) {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -83,8 +83,20 @@ task executeBuild(type: Exec) {
     commandLine 'make', 'images'
 }
 
-task executeTestBuild(type: Exec) {
+task executeAdditionalTargets(type: Exec) {
     dependsOn executeBuild
+    if (project.additionalMakeTargets) {
+        workingDir "$buildRoot"
+        def command = ['make']
+        command += project.additionalMakeTargets
+        commandLine command.flatten()
+    } else {
+        commandLine 'echo', 'No additional targets specified'
+    }
+}
+
+task executeTestBuild(type: Exec) {
+    dependsOn executeAdditionalTargets
     workingDir "$buildRoot"
     commandLine 'make','test-image'
 }


### PR DESCRIPTION
Adding the ability add build additional targets via make to facilitate easier testing.

The extra targets can be passed to gradle as `-Pcorretto.additional_make_targets=target1,target2` and will result in `make target1 target2` getting executed after `make images`. Similar changes maybe made for additional platforms as needed.