### PR TITLE
Excluding async prof binaries from tests

### DIFF
--- a/test/jdk/tools/launcher/HelpFlagsTest.java
+++ b/test/jdk/tools/launcher/HelpFlagsTest.java
@@ -64,6 +64,9 @@ public class HelpFlagsTest extends TestHelper {
         "jweblauncher",
         "jcontrol",
         "ssvagent"
+        // asprof don't test
+        "asprof",
+        "jfrconv"
     };
 
     // Lists which tools support which flags.

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -44,6 +44,7 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -J-option
     static final String[] BLACKLIST_JOPTION = {
+        "asprof",
         "controlpanel",
         "jabswitch",
         "java-rmi",
@@ -57,6 +58,7 @@ public class VersionCheck extends TestHelper {
         "javaw",
         "javaws",
         "jcontrol",
+        "jfrconv",
         "jmc",
         "jmc.ini",
         "jweblauncher",
@@ -67,6 +69,7 @@ public class VersionCheck extends TestHelper {
 
     // tools that do not accept -version
     static final String[] BLACKLIST_VERSION = {
+        "asprof",
         "controlpanel",
         "jaccessinspector",
         "jaccessinspector-32",
@@ -85,6 +88,7 @@ public class VersionCheck extends TestHelper {
         "jdeprscan",
         "jdeps",
         "jfr",
+        "jfrconv",
         "jimage",
         "jinfo",
         "jlink",


### PR DESCRIPTION
Excluding async prof binaries from test checks. Change has been merged for 25 and below already.