### PR TITLE
Add -Pcorretto.make_options Gradle flag to pass extra options to 'make'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,8 @@ allprojects {
             }
         }
 
+        correttoMakeOptions = project.findProperty("corretto.make_options") ?: ""
+
         // Determine the system architecture
         def jdkArch = ""
         def os = ""

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -97,15 +97,16 @@ task configureBuild(type: Exec) {
 
 task executeBuild(type: Exec) {
     dependsOn configureBuild
-    workingDir "$buildRoot"
-    commandLine 'make', 'images'
     outputs.dir jdkResultingImage
+    workingDir "$buildRoot"
+    commandLine 'bash', '-c', "make images ${project.correttoMakeOptions}"
 }
 
 task createTestImage(type: Exec) {
     dependsOn executeBuild
+    outputs.dir testResultingImage
     workingDir "$buildRoot"
-    commandLine 'make','test-image'
+    commandLine 'bash', '-c', "make test-image ${project.correttoMakeOptions}"
 }
 
 task bundleThirdPartyBinaries {

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -87,15 +87,16 @@ task configureBuild(type: Exec) {
 
 task executeBuild(type: Exec) {
     dependsOn configureBuild
-    workingDir "$buildRoot"
-    commandLine 'make', 'images'
     outputs.dir jdkResultingImage
+    workingDir "$buildRoot"
+    commandLine 'bash', '-c', "make images ${project.correttoMakeOptions}"
 }
 
 task createTestImage(type: Exec) {
     dependsOn executeBuild
+    outputs.dir testResultingImage
     workingDir "$buildRoot"
-    commandLine 'make','test-image'
+    commandLine 'bash', '-c', "make test-image ${project.correttoMakeOptions}"
 }
 
 task bundleThirdPartyBinaries {

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -79,8 +79,9 @@ task configureBuild(type: Exec) {
 
 task executeBuild(type: Exec) {
     dependsOn configureBuild
+    outputs.dir jdkResultingImage
     workingDir "$buildRoot"
-    commandLine 'make', 'images'
+    commandLine 'bash', '-c', "make images ${project.correttoMakeOptions}"
 }
 
 task executeAdditionalTargets(type: Exec) {
@@ -89,7 +90,11 @@ task executeAdditionalTargets(type: Exec) {
         workingDir "$buildRoot"
         def command = ['make']
         command += project.additionalMakeTargets
-        commandLine command.flatten()
+	if (project.correttoMakeOptions.isEmpty()) {
+	    commandLine command.flatten()
+	} else {
+	    commandLine 'bash', '-c', "${command.flatten()} ${project.correttoMakeOptions}"
+	}
     } else {
         commandLine 'echo', 'No additional targets specified'
     }
@@ -97,8 +102,9 @@ task executeAdditionalTargets(type: Exec) {
 
 task executeTestBuild(type: Exec) {
     dependsOn executeAdditionalTargets
+    outputs.dir testResultingImage
     workingDir "$buildRoot"
-    commandLine 'make','test-image'
+    commandLine 'bash', '-c', "make test-image ${project.correttoMakeOptions}"
 }
 
 task prepareArtifacts {

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -56,15 +56,16 @@ task configureBuild(type: Exec) {
 
 task executeBuild(type: Exec) {
     dependsOn configureBuild
-    workingDir buildRoot
-    commandLine 'make', 'images'
     outputs.dir jdkResultingImage
+    workingDir buildRoot
+    commandLine 'bash', '-c', "make images ${project.correttoMakeOptions}"
 }
 
 task createTestImage(type: Exec) {
     dependsOn executeBuild
+    outputs.dir testResultingImage
     workingDir "$buildRoot"
-    commandLine 'make','test-image'
+    commandLine 'bash', '-c', "make test-image ${project.correttoMakeOptions}"
 }
 
 task packageTestImage(type: Zip) {


### PR DESCRIPTION
### Description
Add a command-line parameter that passes arguments to make on all platforms:

```
./gradlew ... -Pcorretto.make_options="LOG=trace" ...
```

### Motivation and context
Used it to verify that compilation options are passed to the compiler

### How has this been tested?
Manually tested it on Windows, Alpine Linux, Universal linux, MacOS build targets: building without new parameter, with `-Pcorretto.make_options="LOG=trace"`, and with `-Pcorretto.make_options="LOG=trace CFLAGS=-DTESTING_TESTING_123"`

### Platform information
Windows, Linux flavors, MacOS
