### PR TITLE
Pulling debugsymbols from symbols directory

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -40,6 +40,7 @@ ext {
     }
 }
 def jdkResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/jdk"
+def debugSymbolsResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/symbols"
 def testResultingImage = "$buildRoot/build/linux-${arch}-server-${correttoDebugLevel}/images/test"
 
 // deps
@@ -146,7 +147,7 @@ task packageDebugSymbols(type: Tar) {
     description = 'Package debug symbols'
     archiveFileName = "amazon-corretto-debugsymbols-${project.version.full}-alpine-linux-${arch_alias}.tar.gz"
     compression = Compression.GZIP
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -30,6 +30,7 @@ if (project.correttoArch == 'x86') {
 
 def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 
 // deps
@@ -158,7 +159,7 @@ task packageDebugSymbols(type: Tar) {
     dependsOn packageTestImage
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression = Compression.GZIP
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -33,6 +33,7 @@ configurations {
 // consts
 def imageDir= "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk-bundle"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 def correttoMacDir = "amazon-corretto-${project.version.major}.jdk"
 
@@ -197,10 +198,10 @@ task packageDebugSymbols(type: Tar) {
     description 'Package debug symbols'
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.tar.gz"
     compression Compression.GZIP
-    from("${jdkResultingImage}/${correttoMacDir}") {
-        include "Contents/Home/bin/*.diz"
-        include "Contents/Home/lib/*.diz"
-        include "Contents/Home/lib/server/*.diz"
+    from("${debugSymbolsResultingImage}") {
+        include "bin/*.diz"
+        include "lib/*.diz"
+        include "lib/server/*.diz"
     }
     into "${buildDir}/${correttoMacDir}"
     into project.correttoDebugSymbolsArchiveName

--- a/installers/windows/zip/build.gradle
+++ b/installers/windows/zip/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
 def imageDir = "$buildRoot/build/${project.jdkImageName}/images"
 def jdkResultingImage = "${imageDir}/jdk"
+def debugSymbolsResultingImage = "${imageDir}/symbols"
 def testResultingImage = "${imageDir}/test"
 
 // deps
@@ -81,7 +82,7 @@ task packageDebugSymbols(type: Zip) {
     dependsOn packageTestImage
     archiveFileName = "${project.correttoDebugSymbolsArchiveName}.zip"
 
-    from(jdkResultingImage) {
+    from(debugSymbolsResultingImage) {
         include 'bin/*.diz'
         include 'lib/*.diz'
         include 'lib/server/*.diz'


### PR DESCRIPTION
Pulling debug symbols from the dedicated directory (when building with zipped symbols as scripts do: https://github.com/satyenme/corretto-jdk/blob/e9f00868b9806c3c6a67600968e8bd2a3932061c/build.gradle#L137-L146). 

Tested on windows, linux, and macos with fastdebug and release builds. Compared size of artifacts to size prior to debug symbol generation changes (stemming from https://github.com/openjdk/jdk/pull/28829 and https://github.com/openjdk/jdk/pull/24057) to confirm fix has correct behavior.