### PR TITLE
Add option -Pcorretto.excludeRootLegalFiles=false|true

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,11 +96,17 @@ allprojects {
                 "--with-vendor-version-string=Corretto-${project.version.full}"
         ]
 
+        rootFiles = ['README.md', 'commitId.txt', 'version.txt']
+
         // If this is a certified release build, exclude the README.JAVASE file
         excludeReadmeJavaSE = Boolean.parseBoolean(project.findProperty("corretto.excludeReadmeJavaSE"))
-        rootFiles = ['README.md', 'commitId.txt', 'version.txt']
         if (!excludeReadmeJavaSE) {
             rootFiles += 'README.JAVASE'
+        }
+        // Optionally exclude copies of legal files from root directory for size-optimized builds
+        excludeRootLegalFiles = Boolean.parseBoolean(project.findProperty("corretto.excludeRootLegalFiles"))
+        if (!excludeRootLegalFiles) {
+            rootFiles.addAll(['ADDITIONAL_LICENSE_INFO', 'ASSEMBLY_EXCEPTION', 'LICENSE'])
         }
 
         // If the version opt is empty, then the JDK will set to  'adhoc.<username>.<base dir name>'

--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -165,11 +165,7 @@ task packageBuildResults {
     def outputTarFile = "${distributionDir}/${jdkArchiveName}.tar"
     def prefix = jdkArchiveName
 
-    // Omit legal files in the root of the package
-    def javaBaseLegalFiles = file("$jdkResultingImage/legal/java.base").listFiles().findAll { it.isFile() }.collect { it.name };
-    def rootFilesNoLegal = project.rootFiles.findAll { !(it in javaBaseLegalFiles) }
-
-    inputs.files(rootFilesNoLegal)
+    inputs.files(rootFiles)
     inputs.dir(jdkResultingImage)
     outputs.file("${outputTarFile}.gz")
 
@@ -183,7 +179,7 @@ task packageBuildResults {
             output=`realpath "$outputTarFile"`
             rm -f "\$output.gz"
             pushd "$buildRoot"
-            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFiles.join('" "')}"
             popd
             pushd "$jdkResultingImage"
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1 release

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -175,11 +175,7 @@ task packageBuildResults {
     def outputTarFile = "${distributionDir}/${project.correttoJdkArchiveName}.tar"
     def prefix = project.correttoJdkArchiveName
 
-    // Omit legal files in the root of the package
-    def javaBaseLegalFiles = file("$jdkResultingImage/legal/java.base").listFiles().findAll { it.isFile() }.collect { it.name };
-    def rootFilesNoLegal = project.rootFiles.findAll { !(it in javaBaseLegalFiles) }
-
-    inputs.files(rootFilesNoLegal)
+    inputs.files(rootFiles)
     inputs.dir(jdkResultingImage)
     outputs.file("${outputTarFile}.gz")
 
@@ -193,7 +189,7 @@ task packageBuildResults {
             output=`realpath "$outputTarFile"`
             rm -f "\$output.gz"
             pushd "$buildRoot"
-            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
+            bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFiles.join('" "')}"
             popd
             pushd "$jdkResultingImage"
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1


### PR DESCRIPTION
...to exclude the following files from JDK root directory: ADDITIONAL_LICENSE_INFO, ASSEMBLY_EXCEPTION, LICENSE to save on expanded image size, as these files already present in legal/java.base directory