### PR TITLE
Make <jdk>/jmods directory optional for bsdtar command during the build process

### DIFF
--- a/installers/linux/alpine/tar/build.gradle
+++ b/installers/linux/alpine/tar/build.gradle
@@ -186,7 +186,7 @@ task packageBuildResults {
             bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1 release
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' bin conf include lib man/man1 release \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal

--- a/installers/linux/universal/tar/build.gradle
+++ b/installers/linux/universal/tar/build.gradle
@@ -196,7 +196,7 @@ task packageBuildResults {
             bsdtar -cvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' "${rootFilesNoLegal.join('" "')}"
             popd
             pushd "$jdkResultingImage"
-            bsdtar -rvf "\$output" -s '|^|$prefix/|S' --exclude '*.diz' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' bin conf include jmods lib man/man1
+            bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' --exclude '*.diz' bin conf include lib man/man1 \$(for i in jmods; do [[ -d \$i ]] && echo "\$i" || true; done)
             find legal -type f | xargs -n100 chmod 444
             find legal -type d | xargs -n100 chmod 755
             bsdtar -rvf "\$output" -s '|^|$prefix/|S' $tarSymlinkOption --uid 0 --uname '' --gid 0 --gname '' legal


### PR DESCRIPTION
### Problem
With --enable-linkable-runtime option no <jdk-root>/jmods directory is present after the build.
bsdtar expects all files/directories given in its argument to exist, otherwise it fails.

### Fix
This fix makes jmods directory optional for bsdtar

### Testing
Manually tested on alpine + universal linux