### PR TITLE
Fix for pulling in debugsymbols for AL builds

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -315,7 +315,7 @@ rm -rf %{buildroot}%{java_home}/demo
 
 # Install debugsymbols
 mkdir -p %{buildroot}%{java_home}/symbols
-cp -a %{java_imgdir}/symbols/ %{buildroot}%{java_home}/symbols/
+cp -a %{java_imgdir}/symbols/. %{buildroot}%{java_home}/symbols/
 
 # Properly set permissions for executables and libs to enable auto-provides scanning
 find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -314,8 +314,7 @@ cp -a %{java_imgdir}/jdk/* %{buildroot}%{java_home}
 rm -rf %{buildroot}%{java_home}/demo
 
 # Install debugsymbols
-mkdir -p %{buildroot}%{java_home}/symbols
-cp -a %{java_imgdir}/symbols/. %{buildroot}%{java_home}/symbols/
+cp -a %{java_imgdir}/symbols/* %{buildroot}%{java_home}
 
 # Properly set permissions for executables and libs to enable auto-provides scanning
 find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;
@@ -453,6 +452,9 @@ fi
 %exclude %{java_lib}/libawt_xawt.so
 %exclude %{java_lib}/libjawt.so
 %exclude %{java_lib}/libsplashscreen.so
+# Exclude debug symbol files
+%exclude %{java_home}/lib/*.diz
+%exclude %{java_home}/lib/server/*.diz
 
 %files devel
 %{java_home}/bin/jar
@@ -519,9 +521,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %files debugsymbols
-%{java_home}/symbols/bin/*.diz
-%{java_home}/symbols/lib/*.diz
-%{java_home}/symbols/lib/server/*.diz
+%{java_home}/bin/*.diz
+%{java_home}/lib/*.diz
+%{java_home}/lib/server/*.diz
 
 %changelog
 * Mon Aug 5 2024 Daniel Hu <costmuch@amazon.com>

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -518,9 +518,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %files debugsymbols
-%{java_home}/bin/*.diz
-%{java_home}/lib/*.diz
-%{java_home}/lib/server/*.diz
+%{java_imgdir}/symbols/bin/*.diz
+%{java_imgdir}/symbols/lib/*.diz
+%{java_imgdir}/symbols/lib/server/*.diz
 
 %changelog
 * Mon Aug 5 2024 Daniel Hu <costmuch@amazon.com>

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -313,6 +313,10 @@ install -d -m 755 %{buildroot}%{java_home}
 cp -a %{java_imgdir}/jdk/* %{buildroot}%{java_home}
 rm -rf %{buildroot}%{java_home}/demo
 
+# Install debugsymbols
+mkdir -p %{buildroot}%{java_home}/symbols
+cp -a %{java_imgdir}/symbols/ %{buildroot}%{java_home}/symbols/
+
 # Properly set permissions for executables and libs to enable auto-provides scanning
 find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;
 find %{buildroot}%{java_home} -type d -exec chmod 755 \\{\\} \\; ;
@@ -449,9 +453,6 @@ fi
 %exclude %{java_lib}/libawt_xawt.so
 %exclude %{java_lib}/libjawt.so
 %exclude %{java_lib}/libsplashscreen.so
-# Exclude debug symbol files
-%exclude %{java_home}/lib/*.diz
-%exclude %{java_home}/lib/server/*.diz
 
 %files devel
 %{java_home}/bin/jar
@@ -518,9 +519,9 @@ fi
 %license %{java_imgdir}/docs/legal
 
 %files debugsymbols
-%{java_imgdir}/symbols/bin/*.diz
-%{java_imgdir}/symbols/lib/*.diz
-%{java_imgdir}/symbols/lib/server/*.diz
+%{java_home}/symbols/bin/*.diz
+%{java_home}/symbols/lib/*.diz
+%{java_home}/symbols/lib/server/*.diz
 
 %changelog
 * Mon Aug 5 2024 Daniel Hu <costmuch@amazon.com>


### PR DESCRIPTION
Related to this PR: https://github.com/corretto/corretto-jdk/pull/151, this PR fixes debugsymbols for AL builds. Stems from https://github.com/openjdk/jdk/pull/28829 and https://github.com/openjdk/jdk/pull/24057. Fix installs debugsymbols from the symbols directory (since they are no longer directly present in the build jdk directory alongside binaries by default.

Tested builds and confirmed output artifacts are correct size and have correct content.