### PR TITLE
Removing debuginfo files in favor of zipped symbols

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -315,6 +315,7 @@ rm -rf %{buildroot}%{java_home}/demo
 
 # Install debugsymbols
 cp -a %{java_imgdir}/symbols/* %{buildroot}%{java_home}
+find %{buildroot}%{java_home} -name "*.debuginfo" -delete
 
 # Properly set permissions for executables and libs to enable auto-provides scanning
 find %{buildroot}%{java_home}/ -name "*.so" -exec chmod 755 \\{\\} \\; ;


### PR DESCRIPTION
.debuginfo files are included for non-release builds by https://bugs.openjdk.org/browse/JDK-8373246.

Since we are using `--with-native-debug-symbols=zipped`, we are already packaging compressed debug symbols and can discard the .debuginfo. This matches the structure of lower versions artifacts.