### PR TITLE
Recommend instead of Require dependencies for AL2023 headless

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -162,6 +162,12 @@ Requires: libXrandr
 Requires: libXtst
 Requires: giflib
 Requires: libpng
+Requires: fontconfig
+Requires: freetype
+Requires: dejavu-sans-fonts
+Requires: dejavu-serif-fonts
+Requires: dejavu-sans-mono-fonts
+Requires: alsa-lib
 # Require headless package.
 Requires: %{name}-headless%{?_isa} = %{epoch}:%{version}-%{release}
 

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -184,16 +184,22 @@ AutoReq: 0
 
 %if "%{dist}" == ".amzn2" || "%{dist}" == ".amzn2int"
 Requires: jpackage-utils
-%else
-Requires: javapackages-filesystem
-%endif
-Requires: zlib
 Requires: fontconfig
 Requires: freetype
 Requires: dejavu-sans-fonts
 Requires: dejavu-serif-fonts
 Requires: dejavu-sans-mono-fonts
 Requires: alsa-lib
+%else
+Requires: javapackages-filesystem
+Recommends: fontconfig
+Recommends: freetype
+Recommends: dejavu-sans-fonts
+Recommends: dejavu-serif-fonts
+Recommends: dejavu-sans-mono-fonts
+Recommends: alsa-lib
+%endif
+Requires: zlib
 Requires: libjpeg
 Requires: ca-certificates
 %if "%{dist}" == ".amzn2"


### PR DESCRIPTION
### Description
Improves dependencies for AL2023+ headless

### Related issues
https://github.com/amazonlinux/amazon-linux-2023/issues/940

### Motivation and context
see issue

### How has this been tested?
n/a

### Platform information
    Works on OS: AL2023+
    Applies to version: Will backport to probably 17+ for now


### Additional context
n/a