### PR TITLE
Bump some XML processing limits that were reduced in 24

### DIFF
--- a/src/java.xml/share/conf/jaxp.properties
+++ b/src/java.xml/share/conf/jaxp.properties
@@ -159,18 +159,18 @@ jdk.xml.dtd.support=allow
 jdk.xml.entityExpansionLimit=2500
 #
 # Limits the total size of all entities that include general and parameter entities.
-# The size is calculated as an aggregation of all entities. The default value is 100000.
-jdk.xml.totalEntitySizeLimit=100000
+# The size is calculated as an aggregation of all entities. The default value is 5*10^7
+jdk.xml.totalEntitySizeLimit=50000000
 #
-# Limits the maximum size of any general entities. The default value is 100000.
-jdk.xml.maxGeneralEntitySizeLimit=100000
+# Limits the maximum size of any general entities. The default value is 5*10^7.
+jdk.xml.maxGeneralEntitySizeLimit=50000000
 #
 # Limits the maximum size of any parameter entities, including the result of
 # nesting multiple parameter entities. The default value is 15000.
 jdk.xml.maxParameterEntitySizeLimit=15000
 #
-# Limits the total number of nodes in all entity references. The default value is 100000.
-jdk.xml.entityReplacementLimit=100000
+# Limits the total number of nodes in all entity references. The default value is 5*10^7
+jdk.xml.entityReplacementLimit=50000000
 #
 # Limits the number of attributes an element can have. The default value is 200.
 jdk.xml.elementAttributeLimit=200

--- a/test/jaxp/TEST.groups
+++ b/test/jaxp/TEST.groups
@@ -1,4 +1,4 @@
-#  Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2013, 2026, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,14 @@ jaxp_all = \
 # No jaxp tests are tier 1.
 tier1 = 
 
-# All jaxp tests are tier 2.
+# All jaxp tests are tier 2, except those in higher tiers.
 tier2 = \
-    :jaxp_all
+    :jaxp_all \
+    -javax/xml/jaxp/unittest/common/EntityReplacementLimitTest.java
 
-# No tier 3 tests.
-tier3 = 
+# Slow tests.
+tier3 = \
+    javax/xml/jaxp/unittest/common/EntityReplacementLimitTest.java
 
 # No tier 4 tests.
 tier4 =

--- a/test/jaxp/javax/xml/jaxp/unittest/common/EntityExpansionLimitTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/EntityExpansionLimitTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /javax/xml/jaxp/unittest
+ * @summary Verifies that totalEntitySizeLimit stops entity expansion attacks
+ *          while staying within the default entityExpansionLimit (2500).
+ *          Uses a large entity referenced multiple times so total size exceeds
+ *          totalEntitySizeLimit without exceeding entityExpansionLimit.
+ *          Warning: this test was developed with a help of generative AI
+ * @run main/othervm -Dtest.parser=sax -Dtest.entitySize=200000 -Dtest.refCount=1 -Dtest.expectFailure=false common.EntityExpansionLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.entitySize=25000 -Dtest.refCount=2500 -Dtest.expectFailure=true common.EntityExpansionLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.entitySize=25000 -Dtest.refCount=2500 -Dtest.expectFailure=true -Djdk.xml.totalEntitySizeLimit=50000000 common.EntityExpansionLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.entitySize=10000 -Dtest.refCount=10000 -Dtest.expectFailure=true -Djdk.xml.entityExpansionLimit=10000 common.EntityExpansionLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.entitySize=10000 -Dtest.refCount=10000 -Dtest.expectFailure=true -Djdk.xml.entityExpansionLimit=0 common.EntityExpansionLimitTest
+ */
+package common;
+
+import java.io.StringReader;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class EntityExpansionLimitTest {
+
+    /**
+     * Builds XML with one large entity referenced refCount times.
+     * Total size = entitySize * refCount.
+     * Expansion count = refCount (must stay <= entityExpansionLimit).
+     */
+    private static String buildRepeatedEntityXml(int entitySize, int refCount) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\"?>\n");
+        sb.append("<!DOCTYPE foo [\n");
+        sb.append("  <!ENTITY big \"").append("A".repeat(entitySize)).append("\">\n");
+        sb.append("]>\n");
+        sb.append("<root>");
+        for (int i = 0; i < refCount; i++) {
+            sb.append("&big;");
+        }
+        sb.append("</root>");
+        return sb.toString();
+    }
+
+    public static void main(String[] args) throws Exception {
+        int entitySize = Integer.parseInt(System.getProperty("test.entitySize"));
+        int refCount = Integer.parseInt(System.getProperty("test.refCount"));
+        boolean expectFailure = Boolean.parseBoolean(System.getProperty("test.expectFailure"));
+        String xml = buildRepeatedEntityXml(entitySize, refCount);
+        try {
+            SAXParserFactory.newInstance().newSAXParser()
+                    .parse(new InputSource(new StringReader(xml)), new DefaultHandler());
+            if (expectFailure) {
+                throw new AssertionError("Expected SAXParseException due to totalEntitySizeLimit");
+            }
+        } catch (SAXParseException e) {
+            if (!expectFailure) {
+                throw new AssertionError("Unexpected SAXParseException: " + e.getMessage(), e);
+            }
+            System.out.println("Expansion stopped: " + e.getMessage());
+            if (!e.getMessage().contains("totalEntitySizeLimit") &&
+                    !e.getMessage().contains("accumulated size")) {
+                throw new AssertionError(
+                        "Expected totalEntitySizeLimit in message: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/common/EntityReplacementLimitTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/EntityReplacementLimitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verifies that jdk.xml.entityReplacementLimit is enforced individually for both DOM and SAX parsers.
+ *          Uses nested doubling entities to generate many replacement nodes.
+ *          Warning: this test was developed with a help of generative AI
+ * @library /javax/xml/jaxp/unittest
+ * @run main/othervm -Xmx512m -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 common.EntityReplacementLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=10 -Djdk.xml.entityReplacementLimit=10 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 common.EntityReplacementLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=10 -Djdk.xml.entityReplacementLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 common.EntityReplacementLimitTest
+ * @run main/othervm -Xmx512m -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.entityReplacementLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 common.EntityReplacementLimitTest
+ * @run main/othervm -Xmx512m -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.entityReplacementLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.entityExpansionLimit=0 common.EntityReplacementLimitTest
+ */
+package common;
+
+import common.util.LimitTestBase;
+import org.xml.sax.SAXParseException;
+
+public class EntityReplacementLimitTest {
+
+    public static void main(String[] args) throws Exception {
+        int expectedLimit = Integer.parseInt(System.getProperty("test.expectedLimit"));
+        String prop = System.getProperty("jdk.xml.entityReplacementLimit");
+        int limit = prop != null ? Integer.parseInt(prop) : expectedLimit;
+        if (limit == 0) {
+            LimitTestBase.parse(LimitTestBase.buildNestedEntityXml(
+                    LimitTestBase.levelsToExceed(expectedLimit)));
+        } else {
+            int levelsOver = LimitTestBase.levelsToExceed(limit);
+            int levelsUnder = levelsOver - 2;
+            try {
+                LimitTestBase.parse(LimitTestBase.buildNestedEntityXml(levelsOver));
+                throw new AssertionError("Expected SAXParseException");
+            } catch (SAXParseException ex) {
+                if (!ex.getMessage().contains("JAXP00010007")) {
+                    throw new AssertionError(
+                            "Expected JAXP00010007 in message: " + ex.getMessage());
+                }
+            }
+            LimitTestBase.parse(LimitTestBase.buildNestedEntityXml(levelsUnder));
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/common/MaxGeneralEntitySizeLimitTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/MaxGeneralEntitySizeLimitTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verifies that jdk.xml.maxGeneralEntitySizeLimit is enforced individually for both DOM and SAX parsers.
+ *          Warning: this test was developed with a help of generative AI
+ * @library /javax/xml/jaxp/unittest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 common.MaxGeneralEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 common.MaxGeneralEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=50000000 common.MaxGeneralEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 common.MaxGeneralEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=50000000 common.MaxGeneralEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.maxGeneralEntitySizeLimit=0 -Djdk.xml.totalEntitySizeLimit=0 common.MaxGeneralEntitySizeLimitTest
+ */
+package common;
+
+import common.util.LimitTestBase;
+import org.xml.sax.SAXParseException;
+
+public class MaxGeneralEntitySizeLimitTest {
+
+    public static void main(String[] args) throws Exception {
+        int expectedLimit = Integer.parseInt(System.getProperty("test.expectedLimit"));
+        String prop = System.getProperty("jdk.xml.maxGeneralEntitySizeLimit");
+        int limit = prop != null ? Integer.parseInt(prop) : expectedLimit;
+        if (limit == 0) {
+            LimitTestBase.parse(LimitTestBase.buildXml(expectedLimit + 1));
+        } else {
+            try {
+                LimitTestBase.parse(LimitTestBase.buildXml(limit + 1));
+                throw new AssertionError("Expected SAXParseException");
+            } catch (SAXParseException ex) {
+                if (!ex.getMessage().contains("maxGeneralEntitySizeLimit")) {
+                    throw new AssertionError(
+                            "Expected maxGeneralEntitySizeLimit in message: " + ex.getMessage());
+                }
+            }
+            LimitTestBase.parse(LimitTestBase.buildXml(limit));
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/common/TotalEntitySizeLimitTest.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/TotalEntitySizeLimitTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verifies that jdk.xml.totalEntitySizeLimit is enforced individually for both DOM and SAX parsers.
+ *          Uses two entities each under maxGeneralEntitySizeLimit but whose combined size exceeds totalEntitySizeLimit.
+ *          Warning: this test was developed with a help of generative AI
+ * @library /javax/xml/jaxp/unittest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 common.TotalEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 common.TotalEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 -Djdk.xml.totalEntitySizeLimit=50000000 common.TotalEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=dom -Dtest.expectedLimit=50000000 -Djdk.xml.totalEntitySizeLimit=0 common.TotalEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.totalEntitySizeLimit=50000000 common.TotalEntitySizeLimitTest
+ * @run main/othervm -Dtest.parser=sax -Dtest.expectedLimit=50000000 -Djdk.xml.totalEntitySizeLimit=0 common.TotalEntitySizeLimitTest
+ */
+package common;
+
+import common.util.LimitTestBase;
+import org.xml.sax.SAXParseException;
+
+public class TotalEntitySizeLimitTest {
+
+    public static void main(String[] args) throws Exception {
+        int expectedLimit = Integer.parseInt(System.getProperty("test.expectedLimit"));
+        String prop = System.getProperty("jdk.xml.totalEntitySizeLimit");
+        int limit = prop != null ? Integer.parseInt(prop) : expectedLimit;
+        if (limit == 0) {
+            LimitTestBase.parse(LimitTestBase.buildTwoEntityXml(expectedLimit / 2 + 1));
+        } else {
+            int eachSize = limit / 2 + 1;
+            try {
+                LimitTestBase.parse(LimitTestBase.buildTwoEntityXml(eachSize));
+                throw new AssertionError("Expected SAXParseException");
+            } catch (SAXParseException ex) {
+                if (!ex.getMessage().contains("JAXP00010004")) {
+                    throw new AssertionError(
+                            "Expected JAXP00010004 in message: " + ex.getMessage());
+                }
+            }
+            LimitTestBase.parse(LimitTestBase.buildTwoEntityXml(limit / 2));
+        }
+    }
+}

--- a/test/jaxp/javax/xml/jaxp/unittest/common/config/ImplProperties.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/config/ImplProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,8 +102,8 @@ public class ImplProperties {
         "0", "1000000", "3000000", "10000", "5000", "0", "1000", "10", "100", "10000"},
 
         // default values in JDK 24
-        {"false", "false", "continue", "allow", "2500", "100000",
-        "100000", "15000", "100000", "200", "5000", "100", "1000", "10", "100", "10000"},
+        {"false", "false", "continue", "allow", "2500", "50000000",
+        "50000000", "15000", "50000000", "200", "5000", "100", "1000", "10", "100", "10000"},
 
         // default values in jaxp-strict.properties.template, since JDK 23
         {"false", "false", "strict", "allow", "2500", "100000",

--- a/test/jaxp/javax/xml/jaxp/unittest/common/util/LimitTestBase.java
+++ b/test/jaxp/javax/xml/jaxp/unittest/common/util/LimitTestBase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package common.util;
+
+import java.io.StringReader;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Common utilities for XML entity limit tests.
+ */
+public class LimitTestBase {
+
+    /** Builds XML with a single entity of the given character size. */
+    public static String buildXml(int entitySize) {
+        return "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "  <!ENTITY big \"" + "A".repeat(entitySize) + "\">\n" +
+                "]>\n" +
+                "<root>&big;</root>";
+    }
+
+    /**
+     * Builds XML with two entities, each of the given size.
+     * Each entity is under maxGeneralEntitySizeLimit individually,
+     * but their combined size can exceed totalEntitySizeLimit.
+     */
+    public static String buildTwoEntityXml(int eachSize) {
+        return "<?xml version=\"1.0\"?>\n" +
+                "<!DOCTYPE foo [\n" +
+                "  <!ENTITY a \"" + "A".repeat(eachSize) + "\">\n" +
+                "  <!ENTITY b \"" + "B".repeat(eachSize) + "\">\n" +
+                "]>\n" +
+                "<root>&a;&b;</root>";
+    }
+
+    /**
+     * Builds a nested-entity XML where each level doubles the node count.
+     * e0 = "A", e_n = "&e_{n-1};&e_{n-1};".
+     * Level n produces ~2^n entity replacement nodes.
+     */
+    public static String buildNestedEntityXml(int levels) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\"?>\n");
+        sb.append("<!DOCTYPE foo [\n");
+        sb.append("  <!ENTITY e0 \"A\">\n");
+        for (int i = 1; i <= levels; i++) {
+            sb.append("  <!ENTITY e").append(i)
+              .append(" \"&e").append(i - 1).append(";&e").append(i - 1).append(";\">\n");
+        }
+        sb.append("]>\n");
+        sb.append("<root>&e").append(levels).append(";</root>");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the minimum number of nesting levels needed to exceed the given limit.
+     * Each level produces ~2^n nodes.
+     */
+    public static int levelsToExceed(int limit) {
+        return (int) Math.ceil(Math.log(limit + 1) / Math.log(2)) + 1;
+    }
+
+    /**
+     * Parses XML using DOM or SAX based on the test.parser system property.
+     * Defaults to DOM if not set.
+     */
+    public static void parse(String xml) throws Exception {
+        InputSource src = new InputSource(new StringReader(xml));
+        if ("sax".equals(System.getProperty("test.parser"))) {
+            SAXParserFactory.newInstance().newSAXParser()
+                    .parse(src, new DefaultHandler());
+        } else {
+            DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(src);
+        }
+    }
+}


### PR DESCRIPTION
Bump some XML processing limits that were reduced in 24 (JDK-8343006) to accomodate processing of large XML files. Provide new tests for the limits.

Verified by running `test/jaxp/javax/xml/jaxp` os macosx-aarch64 (including the new tests)