### PR TITLE
Align Corretto versioning to match openjdk

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -1,26 +1,30 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -x
+set -xeuo pipefail
 
 UPSTREAM_REMOTE=$1
 
 # Load the current OpenJDK version
 source make/conf/version-numbers.conf
 
-if [[ "${DEFAULT_VERSION_UPDATE}" == "0" ]]; then
-    BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}+ | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
-else
-    BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep jdk-${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE} | grep -vE "(-ga|{})$" | cut -d+ -f 2 |sort -n |tail -1)
-fi
+# strip trailing zeroes: https://openjdk.org/jeps/322
+ELEMENTS=("${DEFAULT_VERSION_FEATURE}" "${DEFAULT_VERSION_INTERIM}" "${DEFAULT_VERSION_UPDATE}" "${DEFAULT_VERSION_PATCH}")
+LAST=${#ELEMENTS[@]}
+while (( LAST > 1 )) && [[ "${ELEMENTS[$((LAST-1))]}" == "0" ]]; do
+  ((LAST--))
+done
+VERSION_STR=$(IFS=.; echo "${ELEMENTS[*]:0:$LAST}")
+
+BUILD_NUMBER=$(git ls-remote --tags ${UPSTREAM_REMOTE} |grep "jdk-${VERSION_STR}+" | grep -vE "(-ga|{})$" | cut -d+ -f 2 | sort -n | tail -1)
 
 # Load the current Corretto version
 CURRENT_VERSION=$(cat version.txt)
 
-if [[ ${CURRENT_VERSION} == ${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER:=0}.* ]]; then
-    echo "Corretto version is current."
+if [[ "${CURRENT_VERSION}" == "${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${DEFAULT_VERSION_PATCH}.${BUILD_NUMBER}" ]]; then
+  echo "Corretto version is current."
 else
-    echo "Updating Corretto version"
-    NEW_VERSION="${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${BUILD_NUMBER}.1"
-    echo  "${NEW_VERSION}" > version.txt
-    git commit -m "Update Corretto version to match upstream: ${NEW_VERSION}" version.txt
+  echo "Updating Corretto version"
+  NEW_VERSION="${DEFAULT_VERSION_FEATURE}.${DEFAULT_VERSION_INTERIM}.${DEFAULT_VERSION_UPDATE}.${DEFAULT_VERSION_PATCH}.${BUILD_NUMBER}"
+  echo "${NEW_VERSION}" > version.txt
+  git commit -m "Update Corretto version to match upstream: ${NEW_VERSION}" version.txt
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ allprojects {
          major   : tokens[0],
          minor   : tokens[1],
          security: tokens[2],
-         build   : tokens[3],
-         revision: tokens[4],
+         patch   : tokens[3],
+         build   : tokens[4],
          upstream: "${tokens[0]}.${tokens[1]}.${tokens[2]}.${tokens[3]}".toString()]
     }.call()
     buildDir = 'corretto-build'

--- a/installers/linux/al2/spec/build.gradle
+++ b/installers/linux/al2/spec/build.gradle
@@ -29,8 +29,8 @@ def tarName = "java-${version.major}-amazon-corretto"
 def tarVersion = "${version.major}.${version.minor}.${version.security}+${version.build}"
 
 def javaVersion = "${version.major}.${version.minor}.${version.security}"
+def patchId = "${version.patch}"
 def buildId = "${version.build}"
-def releaseId = "${version.revision}"
 /**
  * Apply version numbers to the RPM spec file template and copy
  * to the build root.
@@ -47,8 +47,8 @@ task inflateRpmSpec {
                     java_major_version   : version.major,
                     java_security_version   : version.security,
                     java_version        : javaVersion,
+                    patch_id            : patchId,
                     build_id            : buildId,
-                    release_id          : releaseId,
                     version_opt         : versionOpt,
                     version_date        : project.findProperty("corretto.versionDate") ?: "%{nil}",
                     debug_level         : correttoDebugLevel,

--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -18,13 +18,13 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
 # The Corretto github project provides tarfiles with five dotted
-# version parts.  The first four are the typical Java version + build,
-# and the last one is the release ID.
+# version parts.  The first four are the typical Java version parts described: https://openjdk.org/jeps/322,
+# and the last one is the +$BUILD number used in `configure --with-version-build=`.
 %global java_version    $java_version
 %global java_major_version    $java_spec_version
 %global java_security_version    $java_security_version
+%global patch_id        $patch_id
 %global build_id        $build_id
-%global release_id      $release_id
 %global version_opt     $version_opt
 %global version_date    $version_date
 %global experimental_feature     $experimental_feature
@@ -64,7 +64,7 @@
 %global java_imgdir build/linux-%{_arch}-server-$debug_level/images/
 
 # Higher numbers win for the alternatives program.
-%global alternatives_priority %( printf '%02d%02d%02d%02d' %{java_major_version} %{java_security_version} %{build_id} %{release_id} )
+%global alternatives_priority %( printf '%02d%02d%02d%02d' %{java_major_version} %{java_security_version} %{patch_id} %{build_id} )
 
 # Instruct rpmbuild to copy jars rather than de-compress and re-compress.
 %global __jar_repack 0
@@ -114,7 +114,7 @@ AutoReq: 0
 License: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv2.0 and Public Domain and W3C and zlib and ISC and FTL and RSA.
 Vendor: Amazon
 Url: https://github.com/corretto/corretto-${java_spec_version}
-Source0: amazon-corretto-source-%{java_version}.%{build_id}.%{release_id}.tar.gz
+Source0: amazon-corretto-source-%{java_version}.%{patch_id}.%{build_id}.tar.gz
 Source1: jdk%{java_major_version}-manpages.tar.gz
 
 # jpackage-utils/javapackages-filesystem is required for both build and runtime.
@@ -307,7 +307,7 @@ bash ./configure \\
         --with-version-date="%{version_date}" \\
 %endif
         --with-version-build="%{build_id}" \\
-        --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{build_id}.%{release_id}" \\
+        --with-vendor-version-string="Corretto%{?experimental_feature:-%{experimental_feature}}-%{java_version}.%{patch_id}.%{build_id}" \\
         --with-version-pre= \\
         --with-vendor-name="Amazon.com Inc." \\
         --with-vendor-url="https://aws.amazon.com/corretto/" \\

--- a/installers/linux/universal/deb/build.gradle
+++ b/installers/linux/universal/deb/build.gradle
@@ -55,7 +55,7 @@ ospackage {
     // Valid version must start with a digit and only contain [A-Za-z0-9.+:~-]
     // See http://manpages.ubuntu.com/manpages/artful/en/man5/deb-version.5.html
     version = project.version.upstream
-    release = project.version.revision
+    release = project.version.build
 
     url = "${packageInfo.url}"
     vendor = "${packageInfo.vendor}"

--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -49,7 +49,7 @@ def jdkPackageName = "java-${project.version.major}-amazon-corretto-devel"
 
 ospackage {
     version = project.version.upstream
-    release = project.version.revision
+    release = project.version.build
 
     url = "${packageInfo.url}"
     vendor = "${packageInfo.vendor}"
@@ -108,7 +108,7 @@ task generateJdkRpm(type: Rpm) {
     summary = "Amazon Corretto ${project.version.major} development environment"
     packageGroup = 'Development/Tools'
     // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
-    sourcePackage = "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+    sourcePackage = "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.patch}-${project.version.build}.src.rpm"
 
     prefix(jdkHome)
     postInstall file("$buildRoot/scripts/postin_java.sh")


### PR DESCRIPTION
### Description
Aligns Corretto versioning to be closer to that of upstream openjdk. Won't be backported until 2026 Q4

### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
