### PR TITLE
Add distro build flags for AL2027

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -283,13 +283,37 @@ tar -xzf %{SOURCE1} -C manpages
 %define GIFLIB_DEFINE "-DGIFLIB_MAJOR=4"
 %endif
 
+# %%build_cflags/%%build_cxxflags/%%build_ldflags carry the distro's compiler and
+# linker flags (optimization, hardening such as fortify, stack-protector, PIE,
+# relro/now, etc.). They are only defined on distros that provide them, so pull
+# them in with %%{?...} and append them after our own flags. Whole-program LTO
+# (-flto*/-ffat-lto-objects) is stripped out: linking libjvm.so under it makes
+# gcc's lto1 OOM (observed exceeding 690GB combined RAM+swap), so it is not
+# viable for this codebase regardless of how much memory the build host has.
+# -fexceptions is also stripped to avoid additional compilation errors
+%if "%{dist}" == ".amzn2027"
+%global extra_dist_cflags   %(echo '%{?build_cflags}'   | sed -E 's/-flto([a-zA-Z0-9=_,-]*)?//g; s/-ffat-lto-objects//g; s/-fexceptions//g')
+%global extra_dist_cxxflags %(echo '%{?build_cxxflags}' | sed -E 's/-flto([a-zA-Z0-9=_,-]*)?//g; s/-ffat-lto-objects//g; s/-fexceptions//g')
+%endif
+
 bash ./configure \\
+%if "%{dist}" == ".amzn2027"
+%ifarch aarch64
+        --with-extra-cflags="-moutline-atomics%{?GIFLIB_DEFINE: %{GIFLIB_DEFINE}} %{extra_dist_cflags}" \\
+        --with-extra-cxxflags="-moutline-atomics %{extra_dist_cxxflags}" \\
+%else
+        --with-extra-cflags="%{?GIFLIB_DEFINE:%{GIFLIB_DEFINE}} %{extra_dist_cflags}" \\
+        --with-extra-cxxflags="%{extra_dist_cxxflags}" \\
+%endif
+        --with-extra-ldflags="%{?build_ldflags}" \\
+%else
 %ifarch aarch64
         --with-extra-cflags="-moutline-atomics%{?GIFLIB_DEFINE: %{GIFLIB_DEFINE}}" \\
         --with-extra-cxxflags="-moutline-atomics" \\
 %else
 %if "%{?GIFLIB_DEFINE:1}" == "1"
         --with-extra-cflags="%{GIFLIB_DEFINE}" \\
+%endif
 %endif
 %endif
 %if 0%{?additional_configure_options:1}


### PR DESCRIPTION
### Description
Adds distro build flags for AL2027 builds

### Related issues
- https://github.com/corretto/corretto-25/commit/6f2cf3ceee40aa4ea83dcbad17e695bed52697c6
- https://github.com/corretto/corretto-21/commit/151d7e971623ca0e6993f5257f0d273bcc527af7
- https://github.com/corretto/corretto-17/commit/f9cbb4e71057b8fde01c1ec4f9cc803d545baa2c

### Motivation and context
Already in 17-25 Corretto on AL2027

### How has this been tested?
Already in 17-25 Corretto on AL2027

### Platform information
    Works on OS: Amazon Linux 2027 only
    Applies to version: already in 17-25


### Additional context
n/a