### PR TITLE
Fix macos info.plist version string metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,15 @@ allprojects {
     version = {
         def full = file('version.txt').text.trim()
         def tokens = full.tokenize(".")
+        // version.txt does not carry PATCH element, so this is a temp workaround until Corretto versioning change
+        def patchMatcher = rootProject.file('make/conf/version-numbers.conf').text =~
+                /(?m)^\s*DEFAULT_VERSION_PATCH\s*=\s*(\d+)/
+        def patchNum = patchMatcher.find() ? patchMatcher.group(1) : '0'
         [full    : full,
          major   : tokens[0],
          minor   : tokens[1],
          security: tokens[2],
+         patch   : patchNum,
          build   : tokens[3],
          revision: tokens[4],
          upstream: "${tokens[0]}.${tokens[1]}.${tokens[2]}.${tokens[3]}".toString()]

--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -125,7 +125,9 @@ task prepareArtifacts {
         plistTokens["INFO"] = "Amazon Corretto ${project.version.full}-${versionOpt}".toString()
         plistTokens["ID"] = "com.amazon.corretto.${project.version.major}".toString()
         plistTokens["NAME"] = "Amazon Corretto ${project.version.major}".toString()
-        plistTokens["VERSION"] = "${project.version.major}.${project.version.minor}.${project.version.security}".toString()
+        plistTokens["VERSION"] = (project.version.patch.toInteger() > 0
+                ? "${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.patch}"
+                : "${project.version.major}.${project.version.minor}.${project.version.security}").toString()
         plistTokens["BUILD_VERSION"] = "${project.version.full}".toString()
         plistTokens["MACOSX_VERSION_MIN"] = (correttoArch == "x64" ? "10.12" : "11.0")
         plistTokens["VENDOR"] = "Amazon.com Inc."


### PR DESCRIPTION
### Description
Adds openjdk patch version string when it is non-zero

### Related issues
https://github.com/corretto/corretto-25/issues/76

### Motivation and context
See linked issue for more context

### How has this been tested?
On an internal build:
```
% /usr/libexec/java_home -V
Matching Java Virtual Machines (6):
...
    25.0.4.1 (arm64) "Amazon.com Inc." - "Amazon Corretto 25" /Library/Java/JavaVirtualMachines/amazon-corretto-25.jdk/Contents/Home
...
```

```
% plutil -p /Library/Java/JavaVirtualMachines/amazon-corretto-25.jdk/Contents/Info.plist
{
  "CFBundleDevelopmentRegion" => "English"
  "CFBundleExecutable" => "libjli.dylib"
  "CFBundleGetInfoString" => "Amazon Corretto 25.0.4.9.1-LTS"
  "CFBundleIdentifier" => "com.amazon.corretto.25"
  "CFBundleInfoDictionaryVersion" => "7.0"
  "CFBundleName" => "Amazon Corretto 25"
  "CFBundlePackageType" => "BNDL"
  "CFBundleShortVersionString" => "25.0.4.1"
  "CFBundleSignature" => "????"
  "CFBundleVersion" => "25.0.4.9.1"
  "JavaVM" => {
    "JVMCapabilities" => [
      0 => "CommandLine"
    ]
    "JVMMinimumFrameworkVersion" => "13.2.9"
    "JVMMinimumSystemVersion" => "11.0"
    "JVMPlatformVersion" => "25.0.4.1"
    "JVMVendor" => "Amazon.com Inc."
    "JVMVersion" => "25.0.4.1"
  }
  "NSMicrophoneUsageDescription" => "The application is requesting access to the microphone."
}
```

### Platform information
    Works on OS: MacOS only
    Applies to version: 11+ (will backport)


### Additional context
n/a
